### PR TITLE
Allow schema to validate using Xerces-C

### DIFF
--- a/src/main/resources/com/owlcyberdefense/syslog/xsd/common.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/syslog/xsd/common.dfdl.xsd
@@ -136,7 +136,7 @@ SOFTWARE.
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="PriorityValue" type="PriorityValueType" />
+      <xs:element name="PriorityValue" type="sl:PriorityValueType" />
     </xs:sequence>
   </xs:group>
   -->

--- a/src/main/resources/com/owlcyberdefense/syslog/xsd/syslog-rfc5424.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/syslog/xsd/syslog-rfc5424.dfdl.xsd
@@ -149,20 +149,13 @@ SOFTWARE.
   <xs:group name="rfc5424BodyGroup">
     <xs:sequence>
       <xs:choice>
-        <!--
-        NoStructuredData was an element with length="0" and an initiator="-"
-        but that's not portable as IBM DFDL doesn't put that into the infoset.
-        So we model this as a length 1 element instead.
-
-        <xs:element name="NoStructuredData" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1">
+        <xs:element name="NoStructuredData" type="xs:string" dfdl:lengthKind="explicit" dfdl:length="1" fixed="-">
           <xs:annotation>
-          <xs:appinfo source="http://www.ogf.org/dfdl/">
-            <dfdl:assert>{ . eq '-' }</dfdl:assert>
-          </xs:appinfo>
+            <xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:assert test="{ . eq '-' }" />
+            </xs:appinfo>
           </xs:annotation>
         </xs:element>
-        -->
-        <xs:sequence dfdl:initiator="-"/>
         <xs:element name="StructuredData">
           <xs:complexType>
             <xs:sequence>

--- a/src/test/resources/com/owlcyberdefense/syslog/testsSolarwinds.tdml
+++ b/src/test/resources/com/owlcyberdefense/syslog/testsSolarwinds.tdml
@@ -63,12 +63,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -108,6 +109,7 @@ SOFTWARE.
               <ProcID>8710</ProcID>
               <MsgID xsi:nil="true" />
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <Any>%% It's time to make the do-nuts.</Any>
             </Message>
@@ -136,7 +138,7 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>evntslog</AppName>
               <ProcID xsi:nil="true" />
@@ -187,7 +189,7 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>evntslog</AppName>
               <ProcID xsi:nil="true" />
@@ -238,12 +240,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <Timestamp>2003-10-11T22:14:15+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2003-10-11T22:14:15+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -272,12 +275,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <Timestamp>2003-10-11T22:14:15+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2003-10-11T22:14:15+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -310,12 +314,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <Timestamp>2003-10-11T22:14:15+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2003-10-11T22:14:15+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47ABCDEFGHIJKLMNOPQRSTUVWXYZ012</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -348,12 +353,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -389,7 +395,7 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>evntslog</AppName>
               <ProcID xsi:nil="true" />
@@ -433,7 +439,7 @@ SOFTWARE.
     </tdml:document>
     <tdml:errors>
       <tdml:error>alternatives failed</tdml:error>
-      <tdml:error>Initiator '-' not found</tdml:error>
+      <tdml:error>Assertion failed</tdml:error>
       <tdml:error>Failed to populate SDElement</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -457,12 +463,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <Timestamp>2003-10-11T22:14:15+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2003-10-11T22:14:15+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -498,7 +505,7 @@ SOFTWARE.
             <Header>
               <TimestampMonth>Oct</TimestampMonth>
               <TimestampDay>11</TimestampDay>
-              <TimestampTime>22:14:15+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">22:14:15+00:00</TimestampTime>
               <Hostname>mymachine</Hostname>
             </Header>
             <Message>su: 'su root' failed for lonvick on /dev/pts/8</Message>
@@ -534,7 +541,7 @@ SOFTWARE.
             <Header>
               <TimestampMonth>Feb</TimestampMonth>
               <TimestampDay>5</TimestampDay>
-              <TimestampTime>17:32:18+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">17:32:18+00:00</TimestampTime>
               <Hostname>10.0.0.99</Hostname>
             </Header>
             <Message>Use the BFG!</Message>
@@ -565,7 +572,7 @@ SOFTWARE.
               <SequenceNumber>77</SequenceNumber>
               <TimestampMonth>Aug</TimestampMonth>
               <TimestampDay>31</TimestampDay>
-              <TimestampTime>22:26:04+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">22:26:04+00:00</TimestampTime>
               <Facility>PARSER</Facility>
               <Severity>5</Severity>
               <Mnemonic>CFGLOG_LOGGEDCMD</Mnemonic>
@@ -602,7 +609,7 @@ SOFTWARE.
           </OriginalAddress>
           <sl:ESXi>
             <Header>
-              <TimestampNano>2018-04-11T10:32:56.871000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2018-04-11T10:32:56.871000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>Hostd</AppName>
             </Header>
@@ -631,7 +638,7 @@ SOFTWARE.
           </OriginalAddress>
           <sl:ESXi>
             <Header>
-              <Timestamp>2018-04-10T18:34:25+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2018-04-10T18:34:25+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>crond[12345]</AppName>
             </Header>
@@ -706,7 +713,7 @@ SOFTWARE.
             <Header>
               <TimestampMonth>Oct</TimestampMonth>
               <TimestampDay>4</TimestampDay>
-              <TimestampTime>13:39:37+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">13:39:37+00:00</TimestampTime>
               <Hostname>localhost</Hostname>
             </Header>
             <Message>Syslog message 8656001952143 failed processing</Message>

--- a/src/test/resources/com/owlcyberdefense/syslog/testsSyslog.tdml
+++ b/src/test/resources/com/owlcyberdefense/syslog/testsSyslog.tdml
@@ -33,6 +33,7 @@ SOFTWARE.
 -->
 
 <tdml:testSuite suiteName="Syslog"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
                 xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
@@ -55,12 +56,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -83,12 +85,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-08-24T05:14:15-07:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-08-24T05:14:15-07:00</TimestampNano>
               <Hostname>192.0.2.1</Hostname>
               <AppName>myproc</AppName>
               <ProcID>8710</ProcID>
               <MsgID xsi:nil="true" />
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <Any>%% It's time to make the do-nuts.</Any>
             </Message>
@@ -111,7 +114,7 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>evntslog</AppName>
               <ProcID xsi:nil="true" />
@@ -156,7 +159,7 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>evntslog</AppName>
               <ProcID xsi:nil="true" />
@@ -201,12 +204,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <Timestamp>2003-10-11T22:14:15+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2003-10-11T22:14:15+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -229,12 +233,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <Timestamp>2003-10-11T22:14:15+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2003-10-11T22:14:15+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -261,12 +266,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <Timestamp>2003-10-11T22:14:15+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2003-10-11T22:14:15+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47ABCDEFGHIJKLMNOPQRSTUVWXYZ012</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -293,12 +299,13 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>su</AppName>
               <ProcID xsi:nil="true" />
               <MsgID>ID47</MsgID>
             </Header>
+            <NoStructuredData>-</NoStructuredData>
             <Message>
               <UTF8>'su root' failed for lonvick on /dev/pts/8</UTF8>
             </Message>
@@ -328,7 +335,7 @@ SOFTWARE.
           <RFC5424>
             <Header>
               <Version>1</Version>
-              <TimestampNano>2003-10-11T22:14:15.003000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2003-10-11T22:14:15.003000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>evntslog</AppName>
               <ProcID xsi:nil="true" />
@@ -372,7 +379,7 @@ SOFTWARE.
     </tdml:document>
     <tdml:errors>
       <tdml:error>alternatives failed</tdml:error>
-      <tdml:error>Initiator '-' not found</tdml:error>
+      <tdml:error>Assertion failed</tdml:error>
       <tdml:error>Failed to populate SDElement</tdml:error>
     </tdml:errors>
   </tdml:parserTestCase>
@@ -391,7 +398,7 @@ SOFTWARE.
             <Header>
               <TimestampMonth>Oct</TimestampMonth>
               <TimestampDay>11</TimestampDay>
-              <TimestampTime>22:14:15+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">22:14:15+00:00</TimestampTime>
               <Hostname>mymachine</Hostname>
             </Header>
             <Message>su: 'su root' failed for lonvick on /dev/pts/8</Message>
@@ -421,7 +428,7 @@ SOFTWARE.
             <Header>
               <TimestampMonth>Feb</TimestampMonth>
               <TimestampDay>5</TimestampDay>
-              <TimestampTime>17:32:18+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">17:32:18+00:00</TimestampTime>
               <Hostname>10.0.0.99</Hostname>
             </Header>
             <Message>Use the BFG!</Message>
@@ -446,7 +453,7 @@ SOFTWARE.
               <SequenceNumber>77</SequenceNumber>
               <TimestampMonth>Aug</TimestampMonth>
               <TimestampDay>31</TimestampDay>
-              <TimestampTime>22:26:04+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">22:26:04+00:00</TimestampTime>
               <Facility>PARSER</Facility>
               <Severity>5</Severity>
               <Mnemonic>CFGLOG_LOGGEDCMD</Mnemonic>
@@ -477,7 +484,7 @@ SOFTWARE.
           <Severity>3</Severity>
           <sl:ESXi>
             <Header>
-              <TimestampNano>2018-04-11T10:32:56.871000+00:00</TimestampNano>
+              <TimestampNano xsi:type="xs:dateTime">2018-04-11T10:32:56.871000+00:00</TimestampNano>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>Hostd</AppName>
             </Header>
@@ -500,7 +507,7 @@ SOFTWARE.
           <Severity>7</Severity>
           <sl:ESXi>
             <Header>
-              <Timestamp>2018-04-10T18:34:25+00:00</Timestamp>
+              <Timestamp xsi:type="xs:dateTime">2018-04-10T18:34:25+00:00</Timestamp>
               <Hostname>mymachine.example.com</Hostname>
               <AppName>crond[12345]</AppName>
             </Header>
@@ -569,7 +576,7 @@ SOFTWARE.
             <Header>
               <TimestampMonth>Oct</TimestampMonth>
               <TimestampDay>4</TimestampDay>
-              <TimestampTime>13:39:37+00:00</TimestampTime>
+              <TimestampTime xsi:type="xs:time">13:39:37+00:00</TimestampTime>
               <Hostname>localhost</Hostname>
             </Header>
             <Message>Syslog message 8656001952143 failed processing</Message>


### PR DESCRIPTION
Xerces-C has a bug where it cannot correctly validate choices with an empty sequnce as one of the branches. This replaces the empty sequence with an empty complex type, which xerces-C does support. This should also be portable for IBM DFDL. The downside is now the infoset always constains a NoStructureData element, though there is no workaround for this since Xerces-C needs an element in the choice.