### PR TITLE
Remove checks for error messages that no longer appear

### DIFF
--- a/src/test/resources/com/owlcyberdefense/syslog/testsSolarwinds.tdml
+++ b/src/test/resources/com/owlcyberdefense/syslog/testsSolarwinds.tdml
@@ -386,7 +386,6 @@ SOFTWARE.
       <tdml:error>24</tdml:error>
       <tdml:error>24</tdml:error>
       <tdml:error>PriorityValue</tdml:error>
-      <tdml:error>191</tdml:error>
     </tdml:validationErrors>
   </tdml:parserTestCase>
 

--- a/src/test/resources/com/owlcyberdefense/syslog/testsSyslog.tdml
+++ b/src/test/resources/com/owlcyberdefense/syslog/testsSyslog.tdml
@@ -332,7 +332,6 @@ SOFTWARE.
       <tdml:error>24</tdml:error>
       <tdml:error>24</tdml:error>
       <tdml:error>PriorityValue</tdml:error>
-      <tdml:error>191</tdml:error>
     </tdml:validationErrors>
   </tdml:parserTestCase>
 


### PR DESCRIPTION
Due to a change in Daffodil 3.10.0 we no longer perform both incomplete validation and XML validation. As a result some error messages that we expected no longer show up..